### PR TITLE
Move display logic to display.cpp and display.h.

### DIFF
--- a/HelloUniverse/HelloUniverse.ino
+++ b/HelloUniverse/HelloUniverse.ino
@@ -7,8 +7,8 @@ void setup() {
 
 void loop() {
   delay(1000);
-  Display::print_wag_2();
+  Display::print_wave_2();
   
   delay(1000);
-  Display::print_wag_1();
+  Display::print_wave_1();
 }

--- a/HelloUniverse/HelloUniverse.ino
+++ b/HelloUniverse/HelloUniverse.ino
@@ -1,106 +1,14 @@
-#include <LiquidCrystal.h>
+#include "display.h"
 
-LiquidCrystal lcd(14, 15, 5, 4, 3, 2);
-
-void setup() { // Displays Octicat and "GitHub Universe" to LCD
-  lcd.begin(16, 2); // Initializes the LCD and states size in rows, columns
-   
-  byte octotl[8] = //top-left of octicat icon
-  {
-    0b01000,
-    0b01111,
-    0b01111,
-    0b11111,
-    0b10000,
-    0b10010,
-    0b01000,
-    0b01111
-  };
-
-byte octotr[8] = //top-right of octicat icon
-  {
-    0b00010,
-    0b11110,
-    0b11110,
-    0b11111,
-    0b00001,
-    0b01001,
-    0b00010,
-    0b11110
-  };
-
-  byte octobl[8] = //bottom-left of octicat icon
-  {
-    0b00001,
-    0b10011,
-    0b01111,
-    0b00011,
-    0b00101,
-    0b00010,
-    0b00000,
-    0b11111
-  };
-
-  byte octobr[8] = //bottom-right of octicat icon
-  {
-    0b10000,
-    0b11000,
-    0b11000,
-    0b11000,
-    0b10100,
-    0b01000,
-    0b00000,
-    0b11111
-  };
-  
-byte octowv[8] = { //octowave
-  0b10001,
-  0b01011,
-  0b00111,
-  0b00011,
-  0b00101,
-  0b00010,
-  0b00000,
-  0b11111
-};
-
-    // create a new custom character
-    lcd.createChar(0, octotl);
-    lcd.createChar(1, octotr);
-    lcd.createChar(2, octobl);
-    lcd.createChar(3, octobr); 
-    lcd.createChar(4, octowv);
+void setup() {
+  Display::setup();
+  Display::print_all();
 }
 
 void loop() {
-  // set custom character position
-  lcd.setCursor(0, 0);
-  // write custom character 0
-  lcd.write((uint8_t)0);
-  // write custom character 1
-  lcd.write((uint8_t)1);
-  // Displays "GitHub"
-  lcd.write("  GitHub");
-  
-  // set custom character position
-  lcd.setCursor(0, 1);
-  // write custom character 2
-  lcd.write((uint8_t)2);
-  // write custom character 3
-  lcd.write((uint8_t)3);
-  // Displays "Universe"
-  lcd.write("  Universe");
-
   delay(1000);
+  Display::print_wag_2();
   
-  // set custom character position
-  lcd.setCursor(0, 1);
-  // write custom character 2
-  lcd.write((uint8_t)4);
-  // write custom character 3
-  lcd.write((uint8_t)3);
-  // Displays "Universe"
-  lcd.write("  Universe");
-
   delay(1000);
+  Display::print_wag_1();
 }

--- a/HelloUniverse/display.cpp
+++ b/HelloUniverse/display.cpp
@@ -1,0 +1,113 @@
+#include <Arduino.h>
+#include <LiquidCrystal.h>
+#include "display.h"
+
+#define DISPLAY_RS 14
+#define DISPLAY_E  15
+#define DISPLAY_D4 5
+#define DISPLAY_D5 4
+#define DISPLAY_D6 3
+#define DISPLAY_D7 2
+
+namespace Display {
+  LiquidCrystal lcd(
+    DISPLAY_RS,
+    DISPLAY_E,
+    DISPLAY_D4,
+    DISPLAY_D5,
+    DISPLAY_D6,
+    DISPLAY_D7
+  );
+
+  void setup() {
+    //top-left of octicat icon
+    byte octotl[8] = {
+      0b01000,
+      0b01111,
+      0b01111,
+      0b11111,
+      0b10000,
+      0b10010,
+      0b01000,
+      0b01111
+    };
+
+    //top-right of octicat icon
+    byte octotr[8] = {
+      0b00010,
+      0b11110,
+      0b11110,
+      0b11111,
+      0b00001,
+      0b01001,
+      0b00010,
+      0b11110
+    };
+
+    //bottom-left of octicat icon
+    byte octobl[8] = {
+      0b00001,
+      0b10011,
+      0b01111,
+      0b00011,
+      0b00101,
+      0b00010,
+      0b00000,
+      0b11111
+    };
+
+    //bottom-right of octicat icon
+    byte octobr[8] = {
+      0b10000,
+      0b11000,
+      0b11000,
+      0b11000,
+      0b10100,
+      0b01000,
+      0b00000,
+      0b11111
+    };
+
+    //octowave
+    byte octowv[8] = {
+      0b10001,
+      0b01011,
+      0b00111,
+      0b00011,
+      0b00101,
+      0b00010,
+      0b00000,
+      0b11111
+    };
+
+    lcd.begin(16, 2);
+
+    lcd.createChar(0, octotl);
+    lcd.createChar(1, octotr);
+    lcd.createChar(2, octobl);
+    lcd.createChar(3, octobr);
+    lcd.createChar(4, octowv);
+  }
+
+  void print_all() {
+    lcd.setCursor(0, 0);
+    lcd.write((uint8_t)0);
+    lcd.write((uint8_t)1);
+    lcd.write("  GitHub");
+
+    lcd.setCursor(0, 1);
+    lcd.write((uint8_t)2);
+    lcd.write((uint8_t)3);
+    lcd.write("  Universe");
+  }
+
+  void print_wag_1() {
+    lcd.setCursor(0, 1);
+    lcd.write((uint8_t)2);
+  }
+
+  void print_wag_2() {
+    lcd.setCursor(0, 1);
+    lcd.write((uint8_t)4);
+  }
+}

--- a/HelloUniverse/display.cpp
+++ b/HelloUniverse/display.cpp
@@ -101,12 +101,12 @@ namespace Display {
     lcd.write("  Universe");
   }
 
-  void print_wag_1() {
+  void print_wave_1() {
     lcd.setCursor(0, 1);
     lcd.write((uint8_t)2);
   }
 
-  void print_wag_2() {
+  void print_wave_2() {
     lcd.setCursor(0, 1);
     lcd.write((uint8_t)4);
   }

--- a/HelloUniverse/display.h
+++ b/HelloUniverse/display.h
@@ -1,0 +1,11 @@
+#ifndef DISPLAY_H
+#define DISPLAY_H
+
+namespace Display {
+  void setup();
+  void print_all();
+  void print_wag_1();
+  void print_wag_2();
+}
+
+#endif

--- a/HelloUniverse/display.h
+++ b/HelloUniverse/display.h
@@ -4,8 +4,8 @@
 namespace Display {
   void setup();
   void print_all();
-  void print_wag_1();
-  void print_wag_2();
+  void print_wave_1();
+  void print_wave_2();
 }
 
 #endif


### PR DESCRIPTION
This PR moves logic for the display to `display.cpp` and `display.h` in the `Display` namespace.  Printing the graphics has been broken up into three functions: `print_all`, `print_wave_1`, and `print_wave_2`.